### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit] # create アクションもログイン状態でのアクセスを制限する
-  before_action :set_item, only: [:show, :update, :edit]
+  before_action :set_item, only: [:show, :update, :edit, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -40,6 +40,11 @@ class ItemsController < ApplicationController
   
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path,notice: '商品を削除しました'
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit] # create アクションもログイン状態でのアクセスを制限する
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy] # create アクションもログイン状態でのアクセスを制限する
   before_action :set_item, only: [:show, :update, :edit, :destroy]
 
   def index
@@ -43,8 +43,12 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to root_path,notice: '商品を削除しました'
+    if current_user == @item.user
+      @item.destroy
+      redirect_to root_path, notice: '商品を削除しました。'
+    else
+      redirect_to root_path, alert: '他のユーザーの商品は削除できません。'
+    end
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,7 +22,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     <% end %>
     <% if user_signed_in? && current_user != @item.user %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
-  resources :items, only: [:new, :create, :index, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
【What】機能
ユーザーが出品した商品を削除するための機能です。ユーザーが不要な商品を削除したい場合や、取引が成立しなかった場合など、商品情報をシステムから完全に削除する必要がある場合に使用されます。

【Why】目的
・不要な商品の管理: ユーザーが不要となった商品をシステムから削除できるため、自身の商品リストやデータベースを整理できます。これにより、不要な情報の蓄積を避け、管理が容易になります。
・取引のキャンセル: 取引が成立せず、商品が不要になった場合、ユーザーは商品を削除してリストから非表示にすることができます。これにより、他のユーザーが誤って非現実的な商品にアクセスすることを防ぎます。
・データ保護: ユーザーが自身の出品商品を削除できることで、個人情報や機密情報の保護が可能になります。ユーザーが自身の商品情報を適切に管理し、必要のない情報を削除することで、プライバシーとデータセキュリティを確保できます。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
・ログイン時：https://gyazo.com/d5c46a6fd2c0127f220899f5d8904efa
・ログアウト時：https://gyazo.com/04c1bf80bd7cd82c0a5ef33f8d4b70d4